### PR TITLE
Add all-platform content generation feature

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Added "Generate All Content" endpoint and frontend button on VehicleDetailPage.
 
 ## [0.1.1] - 2025-06-14
 

--- a/.FEATURE_LOG.md
+++ b/.FEATURE_LOG.md
@@ -4,6 +4,10 @@ This file tracks all new features added to the project.
 
 ## [Unreleased]
 
+### Full Content Generation
+- Added backend endpoint and frontend integration to generate content for all platforms in a single request.
+- Introduced "Generate All Content" button on `VehicleDetailPage`.
+
 ## 2025-06-14
 
 ### Frontend Enhancements

--- a/frontend/src/pages/VehicleDetailPage.tsx
+++ b/frontend/src/pages/VehicleDetailPage.tsx
@@ -51,6 +51,29 @@ const VehicleDetailPage = () => {
     }
   };
 
+  const handleGenerateAllContent = async () => {
+    if (!id) return;
+
+    try {
+      setIsGenerating(true);
+      const response = await api.generateAllContent(id, selectedTemplate);
+      const content = response.data.data.generatedContent || {};
+      setGeneratedContent({
+        facebook: content.facebook || '',
+        instagram: content.instagram || '',
+        twitter: content.x || '',
+        youtube: content.youtubeScript || '',
+        email: JSON.stringify(content.email, null, 2) || '',
+      });
+      setActiveTab('content');
+    } catch (err) {
+      console.error('Error generating all content:', err);
+      alert('Failed to generate content. Please try again.');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
   if (isLoading) {
     return <VehicleDetailSkeleton />;
   }
@@ -273,8 +296,17 @@ const VehicleDetailPage = () => {
             </div>
             
             <div className="px-4 py-5 sm:p-6">
-              {activeTab === 'details' ? (
+                {activeTab === 'details' ? (
                 <div className="space-y-4">
+                  <div>
+                    <button
+                      onClick={handleGenerateAllContent}
+                      disabled={isGenerating}
+                      className="w-full inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {isGenerating ? 'Generating...' : 'Generate All Content'}
+                    </button>
+                  </div>
                   <div>
                     <h4 className="text-sm font-medium text-gray-700 mb-2">Social Media Content</h4>
                     <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -53,7 +53,11 @@ class ApiClient {
   }
 
   public async generateEmailContent(vehicleId: string, templateType: string): Promise<AxiosResponse> {
-    return this.client.post(`/content/vehicles/${vehicleId}/email`, { templateType });
+    return this.client.post(`/content/vehicles/${vehicleId}/email`, { emailType: templateType });
+  }
+
+  public async generateAllContent(vehicleId: string, emailScenario?: string): Promise<AxiosResponse> {
+    return this.client.post(`/vehicles/${vehicleId}/generate-all-content`, { emailScenario });
   }
 }
 


### PR DESCRIPTION
## Summary
- allow posting `emailType` for email content
- add `generateAllContent` call in API client
- support new backend endpoint from `VehicleDetailPage`
- button for generating all content at once
- log new feature in change log and feature log

## Testing
- `npm run build` (frontend) *(fails: TS1005, etc.)*
- `npm run build` (backend) *(fails: TS7006, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6852e6c4c1788330af11cee5e9ddf4d1